### PR TITLE
feat: create lock file after sync is finished

### DIFF
--- a/.changes/unreleased/Changed-20250115-084936.yaml
+++ b/.changes/unreleased/Changed-20250115-084936.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Create lock file after sync has finished instead of prior to sync
+time: 2025-01-15T08:49:36.541465+01:00

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,18 +71,20 @@ var syncCmd = &cobra.Command{
 			}
 		}
 
+		// Perform the sync
+		err = internal.SyncDirectory(ctx, client, localDir, remoteDir, 20)
+		if err != nil {
+			log.Fatalf("directory sync failed: %v", err)
+		}
+		fmt.Println("Directory synchronized successfully; creating lock file")
+
 		// Create the lockfile (empty file)
 		err = client.UploadFile(ctx, strings.NewReader(""), filepath.Join(remoteDir, lockFile))
 		if err != nil {
 			log.Fatalf("failed to create lock file: %v", err)
 		}
 
-		// Perform the sync
-		err = internal.SyncDirectory(ctx, client, localDir, remoteDir, 20)
-		if err != nil {
-			log.Fatalf("directory sync failed: %v", err)
-		}
-		fmt.Println("Directory synchronized successfully.")
+		fmt.Println("Lock file", lockFile, "created. Sync process finished.")
 	},
 }
 


### PR DESCRIPTION
We want to to create a lock file **after** sync is finished.
If a process is killed during the sync process, the next time it starts it needs to perform the sync again. If the lock file is already there is won't do anything

## Fixes

Move the 'create lock file' logic down

## Notes

Keep in mind that once we have a lease-option for files we can utilize that; create a lock file which we lease, and as long there is an active lease, the process can wait syncing until the lease is released.
However; there is a risk of a lease never to be released which prevents a process from continuing if it relies on the sync process. So we need to think this through well.