### PR TITLE
fix: gracefully exit process when sync can be skipped

### DIFF
--- a/.changes/unreleased/Fixed-20250115-173829.yaml
+++ b/.changes/unreleased/Fixed-20250115-173829.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Gracefully exit when sync can be skipped instead of fatal error
+time: 2025-01-15T17:38:29.053055+01:00

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,8 +41,8 @@ var syncCmd = &cobra.Command{
 		remoteURL, _ := cmd.Flags().GetString("target")
 		lockFile, _ := cmd.Flags().GetString("lockfile")
 
-		if localDir == "" || remoteURL == "" {
-			log.Fatalf("localDir and remoteURL flags are required")
+		if localDir == "" || remoteURL == "" || lockFile == "" {
+			log.Fatalf("source, target and lockfile arguments are required")
 		}
 
 		// Parse the remote URL
@@ -61,14 +61,13 @@ var syncCmd = &cobra.Command{
 		}
 
 		// Check if lock file exists
-		if lockFile != "" {
-			exists, err := client.FileExists(ctx, filepath.Join(remoteDir, lockFile))
-			if err != nil {
-				log.Fatalf("failed to check lock file existence: %v", err)
-			}
-			if exists {
-				log.Fatalf("lock file %s exists, skipping sync", lockFile)
-			}
+		exists, err := client.FileExists(ctx, filepath.Join(remoteDir, lockFile))
+		if err != nil {
+			log.Fatalf("failed to check lock file existence: %v", err)
+		}
+		if exists {
+			fmt.Println("lock file", lockFile, "exists, skipping sync")
+			return
 		}
 
 		// Perform the sync


### PR DESCRIPTION
Whether the process starts or not relies on the exit code of the sync process.
When the sync can be skipped because the lock file is already there, it should not log a fatal error message