### PR TITLE
feat: set Content-Type correctly for javascript and css files

### DIFF
--- a/.changes/unreleased/Added-20250121-150950.yaml
+++ b/.changes/unreleased/Added-20250121-150950.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'GCP: Detection of JS and CSS filetype and set ContentType'
+time: 2025-01-21T15:09:50.953801+01:00

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,7 +78,7 @@ var syncCmd = &cobra.Command{
 		fmt.Println("Directory synchronized successfully; creating lock file")
 
 		// Create the lockfile (empty file)
-		err = client.UploadFile(ctx, strings.NewReader(""), filepath.Join(remoteDir, lockFile))
+		err = client.UploadFile(ctx, strings.NewReader(""), filepath.Join(remoteDir, lockFile), "")
 		if err != nil {
 			log.Fatalf("failed to create lock file: %v", err)
 		}

--- a/internal/provider_azure.go
+++ b/internal/provider_azure.go
@@ -38,7 +38,7 @@ func NewAzureBlobClient(ctx context.Context, bucket string) (*AzureBlobClient, e
 	return &AzureBlobClient{client: client, container: container}, nil
 }
 
-func (c *AzureBlobClient) UploadFile(ctx context.Context, file io.Reader, remotePath string) error {
+func (c *AzureBlobClient) UploadFile(ctx context.Context, file io.Reader, remotePath string, contentType string) error {
 	var tempFile *os.File
 	var err error
 

--- a/internal/provider_gcp.go
+++ b/internal/provider_gcp.go
@@ -22,11 +22,16 @@ func NewGCSClient(ctx context.Context, bucket string) (*GCSClient, error) {
 }
 
 // UploadFile to GCS
-func (c *GCSClient) UploadFile(ctx context.Context, file io.Reader, remotePath string) error {
+func (c *GCSClient) UploadFile(ctx context.Context, file io.Reader, remotePath string, contentType string) error {
 	bucket := c.client.Bucket(c.bucket)
 	obj := bucket.Object(remotePath)
 
 	writer := obj.NewWriter(ctx)
+
+	if contentType != "" {
+		writer.ContentType = contentType
+	}
+
 	defer writer.Close()
 
 	_, err := io.Copy(writer, file)

--- a/internal/provider_s3.go
+++ b/internal/provider_s3.go
@@ -26,7 +26,7 @@ func NewS3Client(ctx context.Context, bucket string) (*S3Client, error) {
 }
 
 // UploadFile to S3
-func (c *S3Client) UploadFile(ctx context.Context, file io.Reader, remotePath string) error {
+func (c *S3Client) UploadFile(ctx context.Context, file io.Reader, remotePath string, contentType string) error {
 	_, err := c.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(c.bucket),
 		Key:    aws.String(remotePath),


### PR DESCRIPTION
Due to security considerations the content types of javascript and css files aren't automatically detected https://stackoverflow.com/questions/70695214/net-http-does-detectcontenttype-support-javascript

Since we need it for our use case (serving NextJS static files) we define the Content Type explicitly in case of .js or .css